### PR TITLE
Benchmarks

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -8,7 +8,6 @@
 ###     Check the presence of extlib (>= 1.5.1) and camlzip (>=1.04)
 ###     Check for recode
 ###     Set the debug flag
-###     Select the camlp4o executable
 ###     Infer the destdir value from the localdest flag
 ###     Infer the ocamlopt value from the debug flag
 ###     Write the variables to the Makefile.config file
@@ -310,9 +309,9 @@ gcc -lz 2>&1 | grep "undefined reference to .main." > /dev/null
 ZLIBFLAG=$?
 
 #
-# Check Camlp4, Unix, and Str
+# Check Unix, and Str
 #
-for pkg in unix str camlp4; do
+for pkg in unix str; do
 location=`$FINDER query $pkg 2> /dev/null`
 if [ $location ]; then
   msg "inf" "Package $pkg found at $location"

--- a/configure.sh
+++ b/configure.sh
@@ -321,9 +321,9 @@ fi
 done
 
 #
-# Check Extlib and Camomile
+# Check Extlib
 #
-for pkg in extlib camomile; do
+for pkg in extlib; do
 location=`$FINDER query $pkg 2> /dev/null`
 if [ $location ]; then
   msg "inf" "Package $pkg found at $location"
@@ -365,7 +365,7 @@ echo "# $makeconfigtemplate" >> $makeconfig
 cat $makeconfigtemplate >> $makeconfig
 
 # write the package list with camlzip or zip
-echo "INCLUDE := -package unix,str,extlib,camomile,"$packagezip >>$makeconfig
+echo "INCLUDE := -package unix,str,extlib,"$packagezip >>$makeconfig
 echo -n "."
 echo " done."
 
@@ -383,7 +383,7 @@ echo -n "  ."
 # Configuration variables
 echo "" >> $metaconfig
 echo "# Variables detected at configure-time" >> $metaconfig
-echo "requires = \"unix,str,extlib,camomile,camlzip,$packagezip\"" >> $metaconfig
+echo "requires = \"unix,str,extlib,camlzip,$packagezip\"" >> $metaconfig
 # The rest from template
 echo "" >> $metaconfig
 echo "# Variables from template at: " >> $metaconfig

--- a/src/Makefile
+++ b/src/Makefile
@@ -57,11 +57,6 @@ ocaml:javalib.cma
 	$(OCAMLMKTOP) $(INCLUDE) -linkpkg -o $@ javalib.cma
 
 # compilation
-jParseSignature.cmo:jParseSignature.ml
-	$(OCAMLC) $(INCLUDE) $(PP) -c $<
-jParseSignature.cmx jParseSignature.o:jParseSignature.ml
-	$(OCAMLOPT) $(INCLUDE) $(PP) $(FOR_PACK) -c $<
-
 .ml.cmo:
 	$(OCAMLC) $(INCLUDE) -I ptrees -c $<
 %.cmx %.o:%.ml
@@ -109,7 +104,7 @@ cleandoc:
 
 # Dependencies
 .depend:../Makefile.config $(MODULE_INTERFACES:=.mli) $(MODULES:=.ml) 
-	$(OCAMLDEP) $(PP) -I ptrees $^ > $@
+	$(OCAMLDEP) -I ptrees $^ > $@
 
 ifneq ($(MAKECMDGOALS),clean)
 ifneq ($(MAKECMDGOALS),cleanall)

--- a/src/jInstruction.ml
+++ b/src/jInstruction.ml
@@ -202,8 +202,12 @@ let opcode2instruction consts bootstrap_methods = function
   | OpInvokeDynamic i ->
       (match get_constant consts i with
        | ConstInvokeDynamic (bmi, ms) ->
-           let bm = bootstrap_methods.(bmi) in
-           JCode.OpInvoke (`Dynamic bm, ms)
+          (try
+             let bm = bootstrap_methods.(bmi) in
+             JCode.OpInvoke (`Dynamic bm, ms)
+           with _ ->
+                 raise (Class_structure_error "Bad entry in bootstrap methods table")
+          )
        | _ -> raise (Class_structure_error "A bootstrap method ref should be an index into the constant ppool that selects a method handle"))
 
   | OpNew i -> JCode.OpNew (get_class consts i)

--- a/src/jLib.ml
+++ b/src/jLib.ml
@@ -11,18 +11,6 @@ module IO = struct
         
 end
 
-module UTF8 = struct
-  
-  include CamomileLibrary.UTF8 (* Camomile *)
-        
-end
-
-module UChar = struct
-
-  include CamomileLibrary.UChar (* Camomile *)
-  
-end
-
 module String = struct
 
   include ExtString.String (* ExtLib *)

--- a/src/jLib.mli
+++ b/src/jLib.mli
@@ -55,31 +55,6 @@ module IO : sig
      
 end
 
-module UChar : sig
-
-  type t
-  val of_char : char -> t
-
-  
-end
-     
-module UTF8 : sig
-
-  type t = string 
-  type index = int 
-  val validate : t -> unit
-  val out_of_range : t -> index -> bool
-  val look : t -> index -> UChar.t         
-  val next : t -> index -> index
-  module Buf : sig
-    type buf = Buffer.t 
-    val create : int -> buf
-    val add_char : buf -> UChar.t -> unit
-    val contents : buf -> t
-  end       
-end
-
-
 module String : sig
 
   val nsplit : string -> string -> string list

--- a/src/jParse.ml
+++ b/src/jParse.ml
@@ -145,16 +145,6 @@ let parse_stackmap_type_info consts ch = match JLib.IO.read_byte ch with
   | 8 -> VUninitialized (read_ui16 ch)
   | n -> raise (Class_structure_error ("Illegal stackmap type: " ^ string_of_int n))
 
-let parse_stackmap_frame consts ch =
-  let parse_type_info_array ch nb_item =
-    JLib.List.init nb_item (fun _ -> parse_stackmap_type_info consts ch)
-  in let offset = read_ui16 ch in
-  let number_of_locals = read_ui16 ch in
-  let locals = parse_type_info_array ch number_of_locals in
-  let number_of_stack_items = read_ui16 ch in
-  let stack = parse_type_info_array ch number_of_stack_items in
-    (offset,locals,stack)
-
 
 (***************************************************************************)
 (* DFr : Addition for 1.6 stackmap *****************************************)
@@ -332,9 +322,9 @@ let rec parse_code consts ch =
     JLib.List.init
       attrib_count
       (fun _ ->
-	 parse_attribute
-	   [`LineNumberTable ; `LocalVariableTable ; `LocalVariableTypeTable; `StackMap]
-	   consts ch) in
+         parse_attribute
+           [`LineNumberTable ; `LocalVariableTable ; `LocalVariableTypeTable; `StackMap]
+           consts ch) in
     {
       c_max_stack = max_stack;
       c_max_locals = max_locals;

--- a/src/jParseSignature.ml
+++ b/src/jParseSignature.ml
@@ -124,208 +124,354 @@ let parse_sig = parser
   | [< typ = parse_type >] -> SValue typ
   | [< sign = parse_method_sig >] -> SMethod sign
 
-let parse_objectType s =
-  try
-    parse_ot (read_utf8 s)
-  with
-      Stream.Failure -> raise (Class_structure_error ("Illegal object type: " ^ s))
-
-let parse_field_descriptor s =
-  try
-    parse_type (read_utf8 s)
-  with
-      Stream.Failure -> raise (Class_structure_error ("Illegal type: " ^ s))
-
 let parse_method_descriptor s =
   try
     parse_method_sig (read_utf8 s)
   with
-      Stream.Failure -> raise (Class_structure_error ("Illegal method signature: " ^ s))
+    Stream.Failure -> raise (Class_structure_error ("Illegal method signature: " ^ s))
 
 let parse_descriptor s =
   try
     parse_sig (read_utf8 s)
   with
-      Stream.Failure -> raise (Class_structure_error ("Illegal signature: " ^ s))
+    Stream.Failure -> raise (Class_structure_error ("Illegal signature: " ^ s))
 
+type tokens_mfd =
+  | MFDChain of int * int
+  | MFDSep | MFDSlash | MFDOpen | MFDClose
+  
+let rec tokenize_mfd s i l =
+  if (i = String.length s) then List.rev l
+  else
+    match s.[i] with
+    | ';' -> tokenize_mfd s (i+1) (MFDSep :: l)
+    | '/' -> tokenize_mfd s (i+1) (MFDSlash :: l)
+    | '(' -> tokenize_mfd s (i+1) (MFDOpen :: l)
+    | ')' -> tokenize_mfd s (i+1) (MFDClose :: l)    
+    | _ -> (match l with
+            | (MFDChain (a,_)) :: tl -> tokenize_mfd s (i+1) ((MFDChain (a,i)) :: tl)
+            | _ -> tokenize_mfd s (i+1) ((MFDChain (i,i)) :: l)
+           )
+         
+let tokenize_mfd s = tokenize_mfd s 0 []
 
+let rec parse_value_type l s =
+  match l with
+  | MFDChain (a, b) :: l' ->
+     if (b = a && l'=[]) then
+       (match s.[a] with
+        | 'B' -> (TBasic `Byte, l')
+        | 'C' -> (TBasic `Char, l')
+        | 'D' -> (TBasic `Double, l')
+        | 'F' -> (TBasic `Float, l')
+        | 'I' -> (TBasic `Int, l')
+        | 'J' -> (TBasic `Long, l')
+        | 'S' -> (TBasic `Short, l')
+        | 'Z' -> (TBasic `Bool, l')
+        | _ -> failwith "Invalid ValueType"
+       )
+     else
+       let obj, l' = parse_object_type l s in
+       (TObject obj, l')
+  | _ -> failwith "Invalid FieldDescriptor"
+       
+and parse_object_type l s =
+  match l with
+  | MFDChain (a, b) :: l' ->
+     (match s.[a] with
+      | 'L' -> parse_class_type (MFDChain (a+1, b) :: l') s []
+      | '[' ->
+         let vt, l'' = parse_value_type (MFDChain (a+1,b) :: l') s in
+         (TArray vt, l'')
+      | _ -> failwith ("Invalid ObjectType : " ^ s)
+     )
+  | _ -> failwith ("Invalid ObjectType : " ^ s)
 
+and parse_class_type l s lcn =
+  match l with
+  | MFDChain (a, b) :: MFDSlash :: l' ->
+     parse_class_type l' s ((String.sub s a (b-a+1)) :: lcn)
+  | MFDChain (a, b) :: MFDSep :: l' ->
+     let lcn = List.rev ((String.sub s a (b-a+1)) :: lcn) in
+     let cl = TClass (make_cn (String.concat "." lcn)) in
+     (cl, l')
+  | _ -> failwith ("Invalid ClassType : " ^ s)
 
+let parse_field_descriptor s =
+  let vt, l = parse_value_type (tokenize_mfd s) s in
+  match l with
+  | [] -> vt
+  | _ -> failwith ("Invalid FieldDescriptor : " ^ s)
+
+let parse_objectType s =
+  let s =
+    match s.[0] with
+    | '[' | 'L' -> s
+    | _ -> Printf.sprintf "L%s;" s in
+  let obj, l = parse_object_type (tokenize_mfd s) s in
+  match l with
+  | [] -> obj
+  | _ -> failwith ("Invalid ObjectType : " ^ s)
+         
 (* Java 5 signature *)
 
-(* this is the type of stream used in this code *)
-type stream = JLib.UChar.t Stream.t
+type tokens =
+  | Chain of int * int
+  | Slash | Sep | WildStar | WildPlus | WildMinus
+  | Suffix | Bound | Throws
+  | OpenSig | CloseSig
+  | OpenGen | CloseGen
+  
+let rec tokenize s i l =
+  if (i = String.length s) then List.rev l
+  else
+    match s.[i] with
+    | '.' -> tokenize s (i+1) (Suffix :: l)
+    | '<' -> tokenize s (i+1) (OpenGen :: l)
+    | '>' -> tokenize s (i+1) (CloseGen :: l)
+    | '(' -> tokenize s (i+1) (OpenSig :: l)
+    | ')' -> tokenize s (i+1) (CloseSig :: l)
+    | '/' -> tokenize s (i+1) (Slash :: l)
+    | '*' -> tokenize s (i+1) (WildStar :: l)
+    | '+' -> tokenize s (i+1) (WildPlus :: l)
+    | '-' -> tokenize s (i+1) (WildMinus :: l)
+    | ':' -> tokenize s (i+1) (Bound :: l)
+    | '^' -> tokenize s (i+1) (Throws :: l)
+    | ';' -> tokenize s (i+1) (Sep :: l)
+    | _ -> (match l with
+            | (Chain (a,_)) :: tl -> tokenize s (i+1) ((Chain (a,i)) :: tl)
+            | _ -> tokenize s (i+1) ((Chain (i,i)) :: l)
+           )
+let tokenize s = tokenize s 0 []
 
-let parse_TypeVariableSignature : stream -> typeVariable = parser
-  | [< 't when t = JLib.UChar.of_char 'T';
-       name = parse_ident (JLib.UTF8.Buf.create 0);
-       'semicolon when semicolon = JLib.UChar.of_char ';'>] -> TypeVariable name
+let parse_BaseType l s =
+  match l with
+  | Chain (a, b) :: tl ->
+     let l' = if (a+1 > b) then tl else Chain (a+1, b) :: tl in
+     (match s.[a] with
+      | 'B' -> `Byte, l'
+      | 'C' -> `Char, l'
+      | 'D' -> `Double, l'
+      | 'F' -> `Float, l'
+      | 'I' -> `Int, l'
+      | 'J' -> `Long, l'
+      | 'S' -> `Short, l'
+      | 'Z' -> `Bool, l'
+      | _ -> failwith "Invalid BaseType"
+     )
+  | _ -> failwith "Invalid BaseType"
 
-let parse_QualifiedName : stream -> class_name = get_name
+let parse_VoidDescriptor l s =
+  match l with
+  | Chain (a, b) :: tl ->
+     let l' = if (a+1 > b) then tl else failwith "Invalid VoidDescriptor" in
+     (match s.[a] with
+      | 'V' -> (None, l')
+      | _ -> failwith "Invalid VoidDescriptor"
+     )
+  | _ -> failwith "Invalid VoidDescriptor"
+       
+let rec parse_PackageSpecifier l s lpack =
+  match l with
+  | Chain (a, b) :: Slash :: l' ->
+     parse_PackageSpecifier l' s (String.sub s a (b-a+1) :: lpack)
+  | _ -> (List.rev lpack, l)
 
-let rec parse_TypeArguments : stream -> typeArgument list =
-  let parse_TypeArgument = parser
-    | [< 'plus when plus = JLib.UChar.of_char '+'; typ = parse_FieldTypeSignature >]
-      -> ArgumentExtends typ
-    | [< 'minus when minus = JLib.UChar.of_char '-'; typ = parse_FieldTypeSignature >]
-      -> ArgumentInherits typ
-    | [< typ = parse_FieldTypeSignature >]
-      -> ArgumentIs typ
-    | [< 'star when star = JLib.UChar.of_char '*' >]
-      -> ArgumentIsAny
-  in
-  let rec parse_more = parser
-    | [< typ = parse_TypeArgument; other = parse_more >] -> typ::other
-    | [< >] -> []
-  in
-    parser
-      | [< 'lt when lt = JLib.UChar.of_char '<';
-	   typ = parse_TypeArgument;
-	   other = parse_more;
-	   'gt when gt = JLib.UChar.of_char '>' >] -> typ::other
-      | [< >] -> []
+let parse_PackageSpecifier l s = parse_PackageSpecifier l s []
 
+let parse_TypeVariableSignature l s =
+  match l with
+  | Chain (a, b) :: Sep :: l' ->
+     (TypeVariable (String.sub s a (b-a+1)), l')
+  | _ -> failwith "Invalid TypeVariableSignature"
 
-and parse_ArrayTypeSignature : stream -> typeSignature = parser
-  | [< 'lb when lb = JLib.UChar.of_char '[';
-       typ = parse_TypeSignature >] -> typ
+let rec parse_TypeArguments l s largs =
+  match l with
+  | WildStar :: l' ->
+     parse_TypeArguments l' s (ArgumentIsAny :: largs)
+  | WildPlus :: l' ->
+     let rts, l'' = parse_ReferenceTypeSignature l' s in
+     parse_TypeArguments l'' s (ArgumentExtends rts :: largs)
+  | WildMinus :: l' ->
+     let rts, l'' = parse_ReferenceTypeSignature l' s in
+     parse_TypeArguments l'' s (ArgumentInherits rts :: largs)
+  | CloseGen :: l' ->
+     (List.rev largs, l')
+  | l' ->
+     let rts, l'' = parse_ReferenceTypeSignature l' s in
+     parse_TypeArguments l'' s (ArgumentIs rts :: largs)
 
-and parse_TypeSignature : stream -> typeSignature = parser
-  | [< ot = parse_FieldTypeSignature >] -> GObject ot
-  | [< bt = parse_base_type >] -> GBasic bt
+and parse_SimpleClassTypeSignature l s =
+  match l with
+  | Chain (a, b) :: OpenGen :: l' ->
+     let type_args, l'' = parse_TypeArguments l' s [] in
+     ({ scts_name = String.sub s a (b-a+1);
+        scts_type_arguments = type_args; }, l'')
+  | Chain (a, b) :: l' ->
+     ({ scts_name = String.sub s a (b-a+1);
+        scts_type_arguments = []; }, l')
+  | _ -> failwith "InvalidSimpleClassTypeSignature"
 
+and parse_ClassTypeSignatureSuffix l s lsuff =
+  match l with
+  | Suffix :: l' ->
+     let scts, l'' = parse_SimpleClassTypeSignature l' s in
+     parse_ClassTypeSignatureSuffix l'' s (scts :: lsuff)
+  | _ -> (List.rev lsuff, l)
 
-and parse_SimpleClassTypeSignature : stream -> simpleClassTypeSignature = parser
-  | [< ident = parse_ident (JLib.UTF8.Buf.create 0); arguments = parse_TypeArguments >]
-    -> {scts_name = ident; scts_type_arguments = arguments;}
+and parse_ClassTypeSignature l s =
+  let package, l = parse_PackageSpecifier l s in
+  let scts, l = parse_SimpleClassTypeSignature l s in
+  let enclosing_classes, l = parse_ClassTypeSignatureSuffix l s [] in
+  let cts = { cts_package = package;
+              cts_enclosing_classes = enclosing_classes;
+              cts_simple_class_type_signature = scts;
+            } in
+  match l with
+  | Sep :: l' -> (cts, l')
+  | _ -> failwith "Invalid ClassTypeSignature"
 
-and parse_ClassTypeSignatureSuffixes : stream -> simpleClassTypeSignature list =
-  let parse_ClassTypeSignatureSuffix = parser
-    | [< 'dot when dot = JLib.UChar.of_char '.'; ct = parse_SimpleClassTypeSignature >]
-      -> ct
-  in parser
-    | [< ct = parse_ClassTypeSignatureSuffix ; others = parse_ClassTypeSignatureSuffixes >]
-      -> ct::others
-    | [< >] -> []
+and parse_ReferenceTypeSignature l s =
+  match l with
+  | Chain (a, b) :: tl ->
+     let l' = Chain (a+1, b) :: tl in
+     (match s.[a] with
+      | 'L' ->
+         let cts, l'' = parse_ClassTypeSignature l' s in
+         (GClass cts, l'')
+      | 'T' ->
+         let tv, l'' = parse_TypeVariableSignature l' s in
+         (GVariable tv, l'')
+      | '[' ->
+         let jts, l'' = parse_JavaTypeSignature l' s in
+         (GArray jts, l'')
+      | _ -> failwith "Invalid ReferenceTypeSignature"
+     )
+  | _ -> failwith "Invalid ReferenceTypeSignature"
 
-and parse_ClassTypeSignature : stream -> classTypeSignature = parser
-  | [< 'l when l = JLib.UChar.of_char 'L';
-       qualified_name = parse_QualifiedName;
-       args = parse_TypeArguments;
-       cts = parse_ClassTypeSignatureSuffixes;
-       'semicolon when semicolon = JLib.UChar.of_char ';' >]
-    ->
-      let package = cn_package qualified_name in
-      let ct = cn_simple_name qualified_name in
-      let (current_class,enclosing_classes) =
-	let rev = List.rev ({scts_name = ct;scts_type_arguments = args;}::cts) in
-	let hd = List.hd rev in
-	  (hd,List.rev (List.tl rev))
-      in {
-	  cts_package = package;
-	  cts_enclosing_classes = enclosing_classes;
-	  cts_simple_class_type_signature = current_class;}
+and parse_JavaTypeSignature l s =
+  match l with
+  | Chain (a, _) :: _ ->
+     let c = s.[a] in
+     if (c = 'L' || c = 'T' || c = '[') then
+       let rts, l' = parse_ReferenceTypeSignature l s in
+       (GObject rts, l')
+     else
+       let bt, l' = parse_BaseType l s in
+       (GBasic bt, l')
+  | _ -> failwith "Invalid JavaTypeSignature"
 
-and parse_FieldTypeSignature : stream -> fieldTypeSignature = parser
-  | [< ct = parse_ClassTypeSignature >] -> GClass ct
-  | [< at = parse_ArrayTypeSignature >] -> GArray at
-  | [< tv = parse_TypeVariableSignature >] -> GVariable tv
+let parse_Result l s =
+  match l with
+  | Chain (a, _) :: _ ->
+     if (s.[a] = 'V') then parse_VoidDescriptor l s
+     else
+       let jts, l' = parse_JavaTypeSignature l s in
+       (Some jts, l')
+  | _ -> failwith "Invalid Result"
 
-let parse_ClassBound : stream -> fieldTypeSignature option = parser
-  | [< 'colon when colon= JLib.UChar.of_char ':';
-       e = (parser
-	      | [< typ = parse_FieldTypeSignature >] -> Some typ
-	      | [< >] -> None) >] -> e
+let rec parse_InterfaceBounds l s lib =
+  match l with
+  | Bound :: l' ->
+     let rts, l'' = parse_ReferenceTypeSignature l' s in
+     parse_InterfaceBounds l'' s (rts :: lib)
+  | _ -> (List.rev lib, l)
 
+let rec parse_TypeParameters l s ltp =
+  match l with
+  | Chain (a, b) :: Bound :: l' ->
+     let name = String.sub s a (b-a+1) in
+     (match l' with
+      | Bound :: _ ->
+         let i_bounds, l'' = parse_InterfaceBounds l' s [] in
+         parse_TypeParameters l'' s ({ ftp_name = name;
+                                       ftp_class_bound = None;
+                                       ftp_interface_bounds = i_bounds;
+                                     } :: ltp)
+      | _ ->
+         let rts, l'' = parse_ReferenceTypeSignature l' s in
+         let i_bounds, l'' = parse_InterfaceBounds l'' s [] in
+         parse_TypeParameters l'' s ({ ftp_name = name;
+                                       ftp_class_bound = Some rts;
+                                       ftp_interface_bounds = i_bounds;
+                                     } :: ltp)
+     )
+  | CloseGen :: l' -> (List.rev ltp, l')
+  | _ -> failwith "Invalid TypeParameters"
 
-let rec parse_InterfaceBounds : stream -> fieldTypeSignature list =
-  let parse_InterfaceBound = parser
-    | [< 'colon when colon= JLib.UChar.of_char ':'; typ = parse_FieldTypeSignature >] -> typ
-  in parser
-    | [< ib = parse_InterfaceBound; others = parse_InterfaceBounds >] -> ib::others
-    | [< >] -> []
+let parse_TypeParameters_opt l s =
+  match l with
+  | OpenGen :: l' -> parse_TypeParameters l' s []
+  | _ -> ([], l)
 
+let rec parse_SuperInterfaceSignatures l s lsis =
+  match l with
+  | [] -> List.rev lsis
+  | Chain (a, b) :: l' ->
+     if (s.[a] = 'L') then 
+       let sis, l'' = parse_ClassTypeSignature (Chain (a+1,b) :: l') s in
+       parse_SuperInterfaceSignatures l'' s (sis :: lsis)
+     else
+       failwith "Invalid SuperInterfaceSignatures"
+  | _ -> failwith "Invalid SuperInterfaceSignatures"
+       
+let parse_ClassSignature l s =
+  let ftp, l = parse_TypeParameters_opt l s in
+  let scs, l =
+    match l with
+    | Chain (a,b) :: l' ->
+       if (s.[a] = 'L') then parse_ClassTypeSignature (Chain (a+1,b) :: l') s
+       else failwith "Invalid ClassSignature"
+    | _ -> failwith "Invalid ClassSignature" in
+  let sis = parse_SuperInterfaceSignatures l s [] in
+  { cs_formal_type_parameters = ftp;
+    cs_super_class = scs;
+    cs_super_interfaces = sis;
+  }
 
-let parse_FormalTypeParameters : stream -> formalTypeParameter list =
-  let parse_FormalTypeParameter : stream -> formalTypeParameter = parser
-    | [< name = parse_ident (JLib.UTF8.Buf.create 0); cb = parse_ClassBound; ib = parse_InterfaceBounds >]
-      -> {ftp_name = name; ftp_class_bound = cb; ftp_interface_bounds = ib;}
-  in
-  let rec parse_more = parser
-    | [< typ = parse_FormalTypeParameter ; others = parse_more >] -> typ::others
-    | [< >] -> []
-  in parser
-    | [< 'lt when lt = JLib.UChar.of_char '<';
-	 typ = parse_FormalTypeParameter;
-	 others = parse_more;
-	 'gt when gt = JLib.UChar.of_char '>' >]
-      -> typ::others
-    | [< >] -> []
+let parse_ClassSignature s = parse_ClassSignature (tokenize s) s
 
-let parse_SuperclassSignature : stream -> classTypeSignature = parse_ClassTypeSignature
-let rec parse_SuperinterfaceSignatures : stream -> classTypeSignature list = parser
-  | [< sis = parse_ClassTypeSignature; others = parse_SuperinterfaceSignatures >] -> sis::others
-  | [< >] -> []
+let rec parse_JavaTypeSignature_opt l s ljts =
+  match l with
+  | CloseSig :: l' -> (List.rev ljts, l')
+  | _ ->
+     let jts, l' = parse_JavaTypeSignature l s in
+     parse_JavaTypeSignature_opt l' s (jts :: ljts)
+    
+let parse_TypeSignature l s =
+  match l with
+  | OpenSig :: l' -> parse_JavaTypeSignature_opt l' s []
+  | _ -> failwith "Invalid TypeSignature"
+      
+let rec parse_ThrowsSignature l s ls =
+  match l with
+  | [] -> List.rev ls
+  | Throws :: Chain (a, b) :: l' ->
+     let l' = Chain (a+1, b) :: l' in
+     if (s.[a] = 'L') then
+       let cts, l'' = parse_ClassTypeSignature l' s in
+       parse_ThrowsSignature l'' s (ThrowsClass cts :: ls)
+     else if (s.[a] = 'T') then
+       let cts, l'' = parse_TypeVariableSignature l' s in
+       parse_ThrowsSignature l'' s (ThrowsTypeVariable cts :: ls)
+     else failwith "Invalid ThrowsSignature"
+  | _ -> failwith "Invalid ThrowsSignature"
 
-let parse_ClassSignature : stream -> classSignature = parser
-  | [< ftp = parse_FormalTypeParameters;
-       scs = parse_SuperclassSignature;
-       sis = parse_SuperinterfaceSignatures >] ->
-      {cs_formal_type_parameters = ftp;
-       cs_super_class = scs;
-       cs_super_interfaces = sis;}
+let parse_MethodSignature l s =
+  let ftp, l = parse_TypeParameters_opt l s in
+  let ts, l = parse_TypeSignature l s in
+  let rt, l = parse_Result l s in
+  let th = parse_ThrowsSignature l s [] in
+  { mts_formal_type_parameters = ftp;
+    mts_type_signature = ts;
+    mts_return_type = rt;
+    mts_throws = th; }
 
+let parse_MethodTypeSignature s = parse_MethodSignature (tokenize s) s
 
-let parse_MethodTypeSignature : stream -> methodTypeSignature =
-  let parse_ReturnType : stream -> typeSignature option = parser
-    | [< 'v when v = JLib.UChar.of_char 'V' >] -> None
-    | [< ts = parse_TypeSignature >] -> Some ts
-  in
-  let rec parse_ThrowsSignature : stream -> throwsSignature list = parser
-    | [< 'circ when circ = JLib.UChar.of_char '^';
-	 e = (parser
-		| [< cl = parse_ClassTypeSignature >] -> ThrowsClass cl
-		| [< var = parse_TypeVariableSignature >] -> ThrowsTypeVariable var);
-	 others = parse_ThrowsSignature >] -> e::others
-    | [< >] -> []
-  and parse_TypeSignatures : stream -> typeSignature list = parser
-    | [< ts = parse_TypeSignature ; others = parse_TypeSignatures >] -> ts::others
-    | [< >] -> []
-  in parser
-    | [< fp = parse_FormalTypeParameters;
-	 'lpar when lpar = JLib.UChar.of_char '(';
-	 ts = parse_TypeSignatures;
-	 'rpar when rpar = JLib.UChar.of_char ')';
-	 rt = parse_ReturnType;
-	 throws = parse_ThrowsSignature >]
-      -> { mts_formal_type_parameters = fp;
-	   mts_type_signature = ts;
-	   mts_return_type = rt;
-	   mts_throws = throws;}
-
-let parse_ClassSignature (s:string) : classSignature =
-  try
-    parse_ClassSignature (read_utf8 s)
-  with
-    | Failure _ (* "tl" or "hd" *)
-    | Stream.Error _
-    | Stream.Failure -> raise (Class_structure_error ("Ill-formed class Signature attribute: "^s))
-
-let parse_MethodTypeSignature (s:string) : methodTypeSignature =
-  try
-    parse_MethodTypeSignature (read_utf8 s)
-  with
-    | Failure _ (* "tl" or "hd" *)
-    | Stream.Error _
-    | Stream.Failure -> raise (Class_structure_error ("Ill-formed method Signature attribute: "^s))
-
-
-let parse_FieldTypeSignature (s:string) : fieldTypeSignature =
-  try
-    parse_FieldTypeSignature (read_utf8 s)
-  with
-    | Failure _ (* "tl" or "hd" *)
-    | Stream.Error _
-    | Stream.Failure -> raise (Class_structure_error ("Ill-formed field Signature attribute: "^s))
-
+let parse_FieldTypeSignature s =
+  let fs, l = parse_ReferenceTypeSignature (tokenize s) s in
+  match l with
+  | [] -> fs
+  | _ -> failwith "Invalid FieldTypeSignature"
 

--- a/src/jUnparseSignature.ml
+++ b/src/jUnparseSignature.ml
@@ -113,7 +113,7 @@ and unparse_ClassTypeSignature (cts:classTypeSignature) : string =
   ^ String.concat "."
     (List.map
        unparse_SimpleClassTypeSignature
-       (cts.cts_enclosing_classes @ [cts.cts_simple_class_type_signature]))
+       (cts.cts_simple_class_type_signature :: cts.cts_enclosing_classes))
   ^ ";"
 
 and unparse_FieldTypeSignature : fieldTypeSignature -> string = function

--- a/tests/src/Makefile
+++ b/tests/src/Makefile
@@ -1,19 +1,13 @@
 -include ../../Makefile.config
 
 INC_PATH=-I ../../src
-BIN=jar_parser unparser
+BIN=jar_parser unparser test_parser
 
 .PHONY:clean cleanall
 
-all: test_parser jar_parser unparser
+all: $(BIN)
 
-test_parser:test_parser.ml ../../src/javalib.cmxa
-	$(OCAMLOPT) $(INCLUDE) $(INC_PATH) -linkpkg -w Ae -annot -o $@ javalib.cmxa $^
-
-jar_parser:jar_parser.ml ../../src/javalib.cmxa
-	$(OCAMLOPT) $(INCLUDE) $(INC_PATH) -linkpkg -w Ae -annot -o $@ javalib.cmxa $^
-
-unparser:unparser.ml ../../src/javalib.cmxa
+%:%.ml ../../src/javalib.cmxa
 	$(OCAMLOPT) $(INCLUDE) $(INC_PATH) -linkpkg -w Ae -annot -o $@ javalib.cmxa $^
 
 clean:


### PR DESCRIPTION
* Improving java descriptor and signature parsers : e.g. 10x faster for parsing method type signatures
* Getting rid of camlp4
* Getting rid of camomile : slow and useless for our purpose (even before)
* `javalib` is now about 2x faster for loading a java `.class` file