### PR TITLE
Java 9 compatibility

### DIFF
--- a/.travis-setup.sh
+++ b/.travis-setup.sh
@@ -6,6 +6,7 @@ then
     sudo apt-get update
     sudo apt-get install opam
 else
+    brew install adoptopenjdk/openjdk/adoptopenjdk-openjdk10
     brew install opam ocaml camlp4
     export OCAML_VERSION="system"
 fi

--- a/.travis-setup.sh
+++ b/.travis-setup.sh
@@ -6,8 +6,7 @@ then
     sudo apt-get update
     sudo apt-get install opam
 else
-    brew install adoptopenjdk/openjdk/adoptopenjdk-openjdk10
-    brew install opam ocaml camlp4
+    brew install opam ocaml camlp4    
     export OCAML_VERSION="system"
 fi
 

--- a/.travis.sh
+++ b/.travis.sh
@@ -2,6 +2,7 @@ echo "Working on branch" $TRAVIS_BRANCH
 
 OPAM_DEPENDS="ocamlfind camlzip extlib camomile"
 
+opam switch create $OCAML_VERSION
 opam switch $OCAML_VERSION
 eval `opam config env`
 

--- a/.travis.sh
+++ b/.travis.sh
@@ -1,6 +1,6 @@
 echo "Working on branch" $TRAVIS_BRANCH
 
-OPAM_DEPENDS="ocamlfind camlzip extlib camomile"
+OPAM_DEPENDS="ocamlfind camlzip extlib"
 
 opam switch create $OCAML_VERSION
 opam switch $OCAML_VERSION

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,14 @@ matrix:
       dist: trusty
       sudo: required
       env :
-        - OCAML_VERSION=4.02.3
+        - OCAML_VERSION=4.07.0
     - os: linux
       dist: trusty
       sudo: required
       env :
-        - OCAML_VERSION=4.07.0
+        - OCAML_VERSION=4.08.0
+      jdk :
+        - openjdk11
     - os: osx
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,11 +16,7 @@ matrix:
       sudo: required
       env :
         - OCAML_VERSION=4.08.0
-      jdk :
-        - openjdk11
     - os: osx
-      jdk :
-        - oraclejdk11
 
 notifications:
   email : false

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ matrix:
       jdk :
         - openjdk11
     - os: osx
+      jdk :
+        - oraclejdk11
 
 notifications:
   email : false

--- a/javalib.opam
+++ b/javalib.opam
@@ -14,13 +14,12 @@ build: [
 install: [make "install"]
 remove: ["ocamlfind" "remove" "javalib"]
 depends: [
-  "ocaml" {>= "4.02"}
+  "ocaml" {>= "4.04"}
   "conf-which" {build}
   "ocamlfind" {build}
   "camlzip" {>= "1.05"}
   "camlp4"
   "extlib"
-  "camomile"
 ]
 
 synopsis: "Javalib is a library written in OCaml with the aim to provide a high level representation of Java .class files"

--- a/src/jBasics.ml
+++ b/src/jBasics.ml
@@ -163,6 +163,8 @@ type constant =
   | ConstInvokeDynamic of bootstrap_method_index * method_signature
   | ConstNameAndType of string * descriptor
   | ConstStringUTF8 of string
+  | ConstModule of string
+  | ConstPackage of string
   | ConstUnusable
 
 (* Stackmap type. *)

--- a/src/jBasics.ml
+++ b/src/jBasics.ml
@@ -179,7 +179,14 @@ type verification_type =
 	| VObject of object_type
 	| VUninitialized of int (* creation point *)
 
-type stackmap = (int * verification_type list * verification_type list)
+type stackmap_frame =
+  | SameFrame of int
+  | SameLocals of int * verification_type
+  | SameLocalsExtended of int * int * verification_type
+  | ChopFrame of int * int
+  | SameFrameExtended of int * int
+  | AppendFrame of int * int * verification_type list
+  | FullFrame of int * int * verification_type list * verification_type list
 
 type version = {major :int; minor:int;}
 

--- a/src/jBasics.mli
+++ b/src/jBasics.mli
@@ -325,6 +325,8 @@ type constant =
   | ConstInvokeDynamic of bootstrap_method_index * method_signature
   | ConstNameAndType of string * descriptor
   | ConstStringUTF8 of string
+  | ConstModule of string
+  | ConstPackage of string
   | ConstUnusable
 
 (** {1 Stackmaps}  *)

--- a/src/jBasics.mli
+++ b/src/jBasics.mli
@@ -344,7 +344,14 @@ type verification_type =
   | VUninitialized of int (** creation point *)
 
 (** Stackmap type. *)
-type stackmap = (int* verification_type list * verification_type list)
+type stackmap_frame =
+  | SameFrame of int
+  | SameLocals of int * verification_type
+  | SameLocalsExtended of int * int * verification_type
+  | ChopFrame of int * int
+  | SameFrameExtended of int * int
+  | AppendFrame of int * int * verification_type list
+  | FullFrame of int * int * verification_type list * verification_type list
 
 (** {1 Errors}  *)
 

--- a/src/jClassLow.mli
+++ b/src/jClassLow.mli
@@ -242,17 +242,6 @@ type access_flag = [
 | `AccModule
 ]
 
-
-(** DFr : Addition for 1.6 stackmap. *)
-type stackmap_frame =
-  | SameFrame of int
-  | SameLocals of int * verification_type
-  | SameLocalsExtended of int * int * verification_type
-  | ChopFrame of int * int
-  | SameFrameExtended of int * int
-  | AppendFrame of int * int * verification_type list
-  | FullFrame of int * int * verification_type list * verification_type list
-
 type mp_flags = [ `AccFinal | `AccSynthetic | `AccMandated | `AccRFU of int ]
 
 type method_parameters = {

--- a/src/jClassLow.mli
+++ b/src/jClassLow.mli
@@ -219,6 +219,7 @@ type class_flag = [
 | `AccEnum
 | `AccInterface
 | `AccSuper
+| `AccModule
 ]
 
 type access_flag = [
@@ -238,6 +239,7 @@ type access_flag = [
 | `AccVarArgs
 | `AccAnnotation
 | `AccEnum
+| `AccModule
 ]
 
 

--- a/src/jCode.ml
+++ b/src/jCode.ml
@@ -163,7 +163,7 @@ type jcode = {
   c_line_number_table : (int * int) list option;
   c_local_variable_table : (int * int * string * value_type * int) list option;
   c_local_variable_type_table : (int * int * string * JSignature.fieldTypeSignature * int) list option;
-  c_stack_map : stackmap list option;
+  c_stack_map : stackmap_frame list option;
   c_attributes : (string * string) list;
 }
 

--- a/src/jCode.mli
+++ b/src/jCode.mli
@@ -200,7 +200,7 @@ type jcode = {
   (** (start_pc, length, name, type, index) *)
   c_local_variable_type_table : (int * int * string * JSignature.fieldTypeSignature * int) list option;
   (** LocalVariableTable for generics, described in the JVM Spec se8, §4.7.14 *)
-  c_stack_map : stackmap list option;
+  c_stack_map : stackmap_frame list option;
   c_attributes : (string * string) list;
 }
 

--- a/src/jDumpBasics.ml
+++ b/src/jDumpBasics.ml
@@ -218,11 +218,34 @@ let dump_verification_type = function
   | VObject c -> sprintf "Object %s" (object_value_signature c)
   | VUninitialized off -> sprintf "Uninitialized %d" off
 
-let dump_stackmap ch (offset,locals,stack) =
-  JLib.IO.printf ch "\n      offset=%d,\n      locals=[" offset;
-  List.iter (fun t -> JLib.IO.printf ch "\n        %s" (dump_verification_type t)) locals;
-  JLib.IO.printf ch "],\n      stack=[";
-  List.iter (fun t -> JLib.IO.printf ch "\n        %s" (dump_verification_type t)) stack
+(* let dump_stackmap ch (offset,locals,stack) =
+ *   JLib.IO.printf ch "\n      offset=%d,\n      locals=[" offset;
+ *   List.iter (fun t -> JLib.IO.printf ch "\n        %s" (dump_verification_type t)) locals;
+ *   JLib.IO.printf ch "],\n      stack=[";
+ *   List.iter (fun t -> JLib.IO.printf ch "\n        %s" (dump_verification_type t)) stack *)
+
+let dump_stackmap ch frame =
+  match frame with
+  | SameFrame k -> JLib.IO.printf ch "SameFrame(tag:%d)\n" k
+  | SameLocals (k,vtype) ->
+     JLib.IO.printf ch "SameLocals(tag:%d,%s)\n" k (dump_verification_type vtype)
+  | SameLocalsExtended (k,i,vtype) ->
+     JLib.IO.printf ch "SameLocalsExtended(tag:%d,%d,%s)\n"
+       k i (dump_verification_type vtype)
+  | ChopFrame (k,i) ->
+     JLib.IO.printf ch "ChopFrame(tag:%d,%d)\n" k i
+  | SameFrameExtended (k,i) ->
+     JLib.IO.printf ch "SameFrameExtended(tag:%d,%d)\n" k i
+  | AppendFrame (k,i,vtypes) ->
+     let svtypes = String.concat "," (List.map dump_verification_type vtypes) in
+     JLib.IO.printf ch "AppendFrame(tag:%d,%d,%s)\n" k i svtypes
+  | FullFrame (k,offset,locals,stack) ->
+     JLib.IO.printf ch "FullFrame(tag:%d," k;
+     JLib.IO.printf ch "\n      offset=%d,\n      locals=[" offset;
+     List.iter (fun t -> JLib.IO.printf ch "\n        %s" (dump_verification_type t)) locals;
+     JLib.IO.printf ch "],\n      stack=[";
+     List.iter (fun t -> JLib.IO.printf ch "\n        %s" (dump_verification_type t)) stack;
+     JLib.IO.nwrite_string ch ")\n"
 
 open JCode
 

--- a/src/jDumpBasics.ml
+++ b/src/jDumpBasics.ml
@@ -174,6 +174,8 @@ let rec dump_constant ch = function
       JLib.IO.printf ch "invoke-dynamic : %d %s"
         bmi
         (ms_name ms)
+  | ConstModule s -> JLib.IO.printf ch "module %s" s
+  | ConstPackage s -> JLib.IO.printf ch "package %s" s
 
 let dump_bootstrap_argument ch = function
   | `String s -> dump_constant ch (ConstString s)

--- a/src/jDumpBasics.mli
+++ b/src/jDumpBasics.mli
@@ -105,7 +105,7 @@ val dump_constantpool : 'a JLib.IO.output -> constant array -> unit
 val dump_verification_type : verification_type -> string
 
 val dump_stackmap :
-  'a JLib.IO.output -> stackmap -> unit
+  'a JLib.IO.output -> stackmap_frame -> unit
     (** [dump_stackmap ch sm] prints on [ch] the stackmap [sm]. *)
 
 val dump_exc : 'a JLib.IO.output -> 'b -> JCode.exception_handler -> unit

--- a/src/jDumpLow.ml
+++ b/src/jDumpLow.ml
@@ -204,25 +204,7 @@ let access_flags = function
 
 let string_nwrite ch s = JLib.IO.nwrite_string ch s
                         
-let dump_java6_stackmap ch frame =
-  match frame with
-    | SameFrame k -> JLib.IO.printf ch "SameFrame(tag:%d)\n" k
-    | SameLocals (k,vtype) ->
-	JLib.IO.printf ch "SameLocals(tag:%d,%s)\n" k (dump_verification_type vtype)
-    | SameLocalsExtended (k,i,vtype) ->
-	JLib.IO.printf ch "SameLocalsExtended(tag:%d,%d,%s)\n"
-	  k i (dump_verification_type vtype)
-    | ChopFrame (k,i) ->
-	JLib.IO.printf ch "ChopFrame(tag:%d,%d)\n" k i
-    | SameFrameExtended (k,i) ->
-	JLib.IO.printf ch "SameFrameExtended(tag:%d,%d)\n" k i
-    | AppendFrame (k,i,vtypes) ->
-	let svtypes = String.concat "," (List.map dump_verification_type vtypes) in
-	  JLib.IO.printf ch "AppendFrame(tag:%d,%d,%s)\n" k i svtypes
-    | FullFrame (k,offset,locals,stack) ->
-	JLib.IO.printf ch "FullFrame(tag:%d," k;
-	dump_stackmap ch (offset,locals,stack);
-	string_nwrite ch ")\n"
+let dump_java6_stackmap ch frame = dump_stackmap ch frame
 
 let dump_inner_classes ch icl =
   List.iter

--- a/src/jDumpLow.ml
+++ b/src/jDumpLow.ml
@@ -198,6 +198,7 @@ let access_flags = function
 	      | `AccBridge -> "bridge"
 	      | `AccSuper -> "`AccSuper"
 	      | `AccSynthetic -> "synthetic"
+              | `AccModule -> "module"
 	      | `AccRFU i -> Printf.sprintf "rfu 0x%X" i
 	   ) flags) ^ " "
 

--- a/src/jFile.ml
+++ b/src/jFile.ml
@@ -27,8 +27,8 @@ open JClassLow
 let sep =
   match Sys.os_type with
     | "Unix"
-    | "Cygwin" -> ":"
-    | "Win32" -> ";"
+    | "Cygwin" -> ':'
+    | "Win32" -> ';'
     | _ -> assert false
 
 let replace_dot =
@@ -75,14 +75,14 @@ let open_path s =
 type directories = string list
 
 let make_directories dirs =
-  match JLib.String.nsplit dirs sep with
+  match String.split_on_char sep dirs with
     | [] -> [Filename.current_dir_name]
     | cp ->
 	List.filter is_dir cp
 
 let class_path cp =
   let cp_list =
-    match JLib.String.nsplit cp sep with
+    match String.split_on_char sep cp with
       | [] -> [Filename.current_dir_name]
       | cp -> cp
   in

--- a/src/jFile.mli
+++ b/src/jFile.mli
@@ -29,7 +29,7 @@ type class_path
 
 (** [sep] is the class path separator. It contains a colon (:) under
     Unix and Cygwin and a semi-colon (;) under Windows (or MinGW). *)
-val sep : string
+val sep : char
 
 (** [class_path cp] opens a class path from the list [cp] of
     directories and jar (or zip) files separated by {!JFile.sep}.  jar

--- a/src/jHigh2Low.ml
+++ b/src/jHigh2Low.ml
@@ -95,16 +95,23 @@ let h2l_inner_classes = function
       in
 	[AttributeInnerClasses (List.rev_map h2l_ic icl)]
 
-(* This function only build full frames. We don't try to compress the stackmap
+(* This function only build full frames and append frames (hack, this
+   is not correct !).  We don't try to compress the stackmap
    information like javac. *)
 let h2l_stackmap_table sm : stackmap_frame list =
   let (_,table) =
     List.fold_left
       (fun (last,table) (pc,lv,sv) ->
 	 if (last = 0) then
-	   (pc,FullFrame(255,pc,lv,sv)::table)
+           if sv = [] && List.length lv > 0 && List.length lv < 4 then
+             (pc,AppendFrame(251+(List.length lv),pc,lv)::table)
+           else
+	     (pc,FullFrame(255,pc,lv,sv)::table)
 	 else
 	   let offset_delta = pc - last - 1 in
+           if sv = [] && List.length lv > 0 && List.length lv < 4 then
+             (pc,AppendFrame(251+(List.length lv),offset_delta,lv)::table)
+           else
 	     (pc,FullFrame(255,offset_delta,lv,sv)::table)
       ) (0,[]) sm in
     List.rev table

--- a/src/jHigh2Low.ml
+++ b/src/jHigh2Low.ml
@@ -95,26 +95,7 @@ let h2l_inner_classes = function
       in
 	[AttributeInnerClasses (List.rev_map h2l_ic icl)]
 
-(* This function only build full frames and append frames (hack, this
-   is not correct !).  We don't try to compress the stackmap
-   information like javac. *)
-let h2l_stackmap_table sm : stackmap_frame list =
-  let (_,table) =
-    List.fold_left
-      (fun (last,table) (pc,lv,sv) ->
-	 if (last = 0) then
-           if sv = [] && List.length lv > 0 && List.length lv < 4 then
-             (pc,AppendFrame(251+(List.length lv),pc,lv)::table)
-           else
-	     (pc,FullFrame(255,pc,lv,sv)::table)
-	 else
-	   let offset_delta = pc - last - 1 in
-           if sv = [] && List.length lv > 0 && List.length lv < 4 then
-             (pc,AppendFrame(251+(List.length lv),offset_delta,lv)::table)
-           else
-	     (pc,FullFrame(255,offset_delta,lv,sv)::table)
-      ) (0,[]) sm in
-    List.rev table
+let h2l_stackmap_table sm : stackmap_frame list = sm
 
 let h2l_code2attribute consts bm_table = function
   | Native -> []

--- a/src/jLow2High.ml
+++ b/src/jLow2High.ml
@@ -801,8 +801,6 @@ let low2high_innerclass = function
 	}
 
 let low2high_class cl =
-  if cl.j_super = None && cl.j_name <> JBasics.java_lang_object
-  then raise (Class_structure_error "Only java.lang.Object is allowed not to have a super-class.");
   let flags = cl.j_flags in
   let (access,flags) = flags2access (flags :> access_flag list) in
   let (accsuper,flags) = get_flag `AccSuper flags in
@@ -812,6 +810,9 @@ let low2high_class cl =
   let (is_synthetic,flags) = get_flag `AccSynthetic flags in
   let (is_annotation,flags) = get_flag `AccAnnotation flags in
   let (is_enum,flags) = get_flag `AccEnum flags in
+  let (is_module,flags) = get_flag `AccModule flags in
+  if cl.j_super = None && cl.j_name <> JBasics.java_lang_object && not is_module
+  then raise (Class_structure_error "Only java.lang.Object is allowed not to have a super-class.");
   let flags =
     List.map
       (function

--- a/src/jLow2High.ml
+++ b/src/jLow2High.ml
@@ -96,44 +96,7 @@ let low2high_attributes consts (al:JClassLow.attribute list) :attributes =
 	   al);
   }
 
-let expanse_stackmap_table stackmap_table =
-  let (_,stackmap) =
-    List.fold_left
-      (fun ((pc,l,_),stackmap) frame ->
-	 match frame with
-	   | SameFrame k ->
-	       let offset = pc + k + 1 in
-	       let s = (offset,l,[]) in
-		 (s,s::stackmap)
-	   | SameLocals (k,vtype) ->
-	       let offset = pc + k - 64 + 1 in
-	       let s = (offset,l,[vtype]) in
-		 (s,s::stackmap)
-	   | SameLocalsExtended (_,offset_delta,vtype) ->
-	       let offset = pc + offset_delta + 1 in
-	       let s = (offset,l,[vtype]) in
-		 (s,s::stackmap)
-	   | ChopFrame (k,offset_delta) ->
-	       let offset = pc + offset_delta + 1 in
-	       let nb_chop = 251 - k in
-	       let l_chop = List.rev
-		 (JLib.List.drop nb_chop (List.rev l)) in
-	       let s = (offset,l_chop,[]) in
-		 (s,s::stackmap)
-	   | SameFrameExtended (_,offset_delta) ->
-	       let offset = pc + offset_delta + 1 in
-	       let s = (offset,l,[]) in
-		 (s,s::stackmap)
-	   | AppendFrame (_,offset_delta,vtype_list) ->
-	       let offset = pc + offset_delta + 1 in
-	       let s = (offset,l@vtype_list,[]) in
-		 (s,s::stackmap)
-	   | FullFrame (_,offset_delta,lv,sv) ->
-	       let offset = pc + offset_delta + 1 in
-	       let s = (offset,lv,sv) in
-		 (s,s::stackmap)
-      ) ((-1,[],[]),[]) stackmap_table in
-    List.rev stackmap
+let expanse_stackmap_table stackmap_table = stackmap_table
 
 let low2high_code consts bootstrap_methods = function c ->
   {

--- a/src/jLow2High.ml
+++ b/src/jLow2High.ml
@@ -774,7 +774,8 @@ let low2high_class cl =
   let (is_annotation,flags) = get_flag `AccAnnotation flags in
   let (is_enum,flags) = get_flag `AccEnum flags in
   let (is_module,flags) = get_flag `AccModule flags in
-  if cl.j_super = None && cl.j_name <> JBasics.java_lang_object && not is_module
+  if not (JBasics.get_permissive ()) &&
+       cl.j_super = None && cl.j_name <> JBasics.java_lang_object && not is_module
   then raise (Class_structure_error "Only java.lang.Object is allowed not to have a super-class.");
   let flags =
     List.map

--- a/src/jManifest.mll
+++ b/src/jManifest.mll
@@ -69,7 +69,7 @@ and section = parse
   (* TODO : accept missing manifest version (for midlets) *)
   let sections2manifest = function
       | ((mv, v) :: main) :: sections
-	  when String.lowercase mv = "manifest-version" ->
+	  when String.lowercase_ascii mv = "manifest-version" ->
 	  {main_section =
 	      {manifest_version = List.map int_of_string (JLib.String.nsplit v ".");
 	       main_attributes = main};
@@ -77,7 +77,7 @@ and section = parse
 	      List.map
 		(function
 		   | (name, v) :: attributes
-		       when String.lowercase name = "name" ->
+		       when String.lowercase_ascii name = "name" ->
 		       {name = v ; attributes = attributes}
 		   | _ -> failwith "incorrect manifest")
 		sections}

--- a/src/jParse.ml
+++ b/src/jParse.ml
@@ -109,7 +109,7 @@ let class_flags =
   [|`AccPublic; `AccRFU 0x2; `AccRFU 0x4; `AccRFU 0x8;
     `AccFinal; `AccSuper; `AccRFU 0x40; `AccRFU 0x80;
     `AccRFU 0x100; `AccInterface; `AccAbstract; `AccRFU 0x800;
-    `AccSynthetic; `AccAnnotation; `AccEnum; `AccRFU 0x8000|]
+    `AccSynthetic; `AccAnnotation; `AccEnum; `AccModule|]
 let innerclass_flags =
   [|`AccPublic; `AccPrivate; `AccProtected; `AccStatic;
     `AccFinal; `AccRFU 0x20; `AccRFU 0x40; `AccRFU 0x80;

--- a/src/jParseSignature.ml
+++ b/src/jParseSignature.ml
@@ -93,7 +93,7 @@ let parse_field_descriptor s =
 let parse_objectType s =
   let s =
     match s.[0] with
-    | '[' | 'L' -> s
+    | '[' -> s
     | _ -> Printf.sprintf "L%s;" s in
   let obj, l = parse_object_type (tokenize_mfd s) s in
   match l with

--- a/src/jPrint.ml
+++ b/src/jPrint.ml
@@ -156,27 +156,10 @@ let constant_pool p =
 	   !s ^ "    " ^ (string_of_int i) ^ "  " ^ (constant c) ^ "\n") p;
     !s
 
-(* let stack_map (offset,locals,stack) =
- *   let verif_info = function
- *     | VTop -> "Top"
- *     | VInteger -> "Integer"
- *     | VFloat -> "Float"
- *     | VDouble -> "Double"
- *     | VLong -> "Long"
- *     | VNull -> "Null"
- *     | VUninitializedThis -> "UninitializedThis"
- *     | VObject c -> "Object " ^(object_type c)
- *     | VUninitialized off -> "Uninitialized " ^(string_of_int off)
- *   in
- *   let s = ref (Printf.sprintf "\n      offset=%d,\n      locals=[" offset) in
- *     JLib.List.iter
- *       (fun t ->
- * 	 s := !s ^ Printf.sprintf  "\n        %s" (verif_info t)) locals;
- *     s := !s ^ "],\n      stack=[";
- *     JLib.List.iter
- *       (fun t ->
- * 	 s := Printf.sprintf "\n        %s" (verif_info t)) stack;
- *     !s *)
+let stack_map frame =
+  let ch = JLib.IO.output_string () in
+  let () = JDumpBasics.dump_stackmap ch frame in
+  JLib.IO.close_out ch
 
 open JCode
 let exception_handler exc =

--- a/src/jPrint.ml
+++ b/src/jPrint.ml
@@ -156,27 +156,27 @@ let constant_pool p =
 	   !s ^ "    " ^ (string_of_int i) ^ "  " ^ (constant c) ^ "\n") p;
     !s
 
-let stack_map (offset,locals,stack) =
-  let verif_info = function
-    | VTop -> "Top"
-    | VInteger -> "Integer"
-    | VFloat -> "Float"
-    | VDouble -> "Double"
-    | VLong -> "Long"
-    | VNull -> "Null"
-    | VUninitializedThis -> "UninitializedThis"
-    | VObject c -> "Object " ^(object_type c)
-    | VUninitialized off -> "Uninitialized " ^(string_of_int off)
-  in
-  let s = ref (Printf.sprintf "\n      offset=%d,\n      locals=[" offset) in
-    JLib.List.iter
-      (fun t ->
-	 s := !s ^ Printf.sprintf  "\n        %s" (verif_info t)) locals;
-    s := !s ^ "],\n      stack=[";
-    JLib.List.iter
-      (fun t ->
-	 s := Printf.sprintf "\n        %s" (verif_info t)) stack;
-    !s
+(* let stack_map (offset,locals,stack) =
+ *   let verif_info = function
+ *     | VTop -> "Top"
+ *     | VInteger -> "Integer"
+ *     | VFloat -> "Float"
+ *     | VDouble -> "Double"
+ *     | VLong -> "Long"
+ *     | VNull -> "Null"
+ *     | VUninitializedThis -> "UninitializedThis"
+ *     | VObject c -> "Object " ^(object_type c)
+ *     | VUninitialized off -> "Uninitialized " ^(string_of_int off)
+ *   in
+ *   let s = ref (Printf.sprintf "\n      offset=%d,\n      locals=[" offset) in
+ *     JLib.List.iter
+ *       (fun t ->
+ * 	 s := !s ^ Printf.sprintf  "\n        %s" (verif_info t)) locals;
+ *     s := !s ^ "],\n      stack=[";
+ *     JLib.List.iter
+ *       (fun t ->
+ * 	 s := Printf.sprintf "\n        %s" (verif_info t)) stack;
+ *     !s *)
 
 open JCode
 let exception_handler exc =

--- a/src/jPrint.ml
+++ b/src/jPrint.ml
@@ -144,6 +144,8 @@ let rec constant = function
       "method-handle : " ^ (JDumpBasics.method_handle_kind kind) ^ (constant c)
   | ConstInvokeDynamic (bmi,ms) ->
       "invoke-dynamic : #" ^ (string_of_int bmi) ^ " : " ^ (method_signature ms)
+  | ConstModule s -> "module " ^ s
+  | ConstPackage s -> "package " ^ s
   | ConstUnusable -> "unusable"
 
 let constant_pool p =

--- a/src/jUnparse.ml
+++ b/src/jUnparse.ml
@@ -473,23 +473,24 @@ let unparse_class_low_level ch c =
   write_ui16 ch c.j_version.major;
   let ch' = JLib.IO.output_string ()
   and consts = JLib.DynArray.of_array c.j_consts in
-    write_ui16 ch' (unparse_flags class_flags c.j_flags);
-    write_class ch' consts c.j_name;
-    write_ui16 ch'
-      (match c.j_super with
-	 | Some super -> constant_to_int consts (ConstClass (TClass super))
-	 | None -> 0);
-    let unparse unparse = write_with_size write_ui16 ch' unparse in
-      unparse
-	(function int -> write_class ch' consts int)
-	c.j_interfaces;
-      unparse (unparse_field ch' consts) c.j_fields;
-      unparse (unparse_method ch' consts) c.j_methods;
-      unparse (unparse_attribute ch' consts) (c.j_attributes
-                                              @ [AttributeBootstrapMethods
-                                                   (Array.to_list c.j_bootstrap_table)]);
-      unparse_constant_pool ch consts;
-      JLib.IO.nwrite_string ch (JLib.IO.close_out ch')
+  write_ui16 ch' (unparse_flags class_flags c.j_flags);
+  write_class ch' consts c.j_name;
+  write_ui16 ch'
+    (match c.j_super with
+     | Some super -> constant_to_int consts (ConstClass (TClass super))
+     | None -> 0);
+  let unparse unparse = write_with_size write_ui16 ch' unparse in
+  let bm_table = Array.to_list c.j_bootstrap_table in
+  unparse
+    (function int -> write_class ch' consts int)
+    c.j_interfaces;
+  unparse (unparse_field ch' consts) c.j_fields;
+  unparse (unparse_method ch' consts) c.j_methods;
+  unparse (unparse_attribute ch' consts) (if bm_table = [] then c.j_attributes
+                                          else c.j_attributes
+                                               @ [AttributeBootstrapMethods bm_table]);
+  unparse_constant_pool ch consts;
+  JLib.IO.nwrite_string ch (JLib.IO.close_out ch')
 
 let unparse_class_low_level ch c =
   try unparse_class_low_level ch c

--- a/src/jUnparse.ml
+++ b/src/jUnparse.ml
@@ -93,6 +93,12 @@ let unparse_constant ch consts =  function
         write_ui16 ch bmi;
         write_name_and_type ch consts ((ms_name ms),
                                        (SMethod (make_md (ms_args ms, ms_rtype ms))))
+    | ConstModule s ->
+       write_ui8 ch 19;
+       write_constant ch consts (ConstStringUTF8 s)
+    | ConstPackage s ->
+       write_ui8 ch 20;
+       write_constant ch consts (ConstStringUTF8 s)
     | ConstUnusable -> ()
 
 let unparse_constant_pool ch consts =

--- a/src/jUnparse.mli
+++ b/src/jUnparse.mli
@@ -48,7 +48,7 @@ val unparse_attribute_to_strings : JBasics.constant JLib.DynArray.t -> JClassLow
 (* For statistics: *)
 
 val unparse_stackmap_table_attribute :
-  JBasics.constant JLib.DynArray.t -> JClassLow.stackmap_frame list -> (string * string)
+  JBasics.constant JLib.DynArray.t -> JBasics.stackmap_frame list -> (string * string)
 
 val unparse_constant_pool :
   'a JLib.IO.output ->

--- a/src/javalib.mli
+++ b/src/javalib.mli
@@ -623,7 +623,7 @@ sig
 
   (** {1 Printing stackmaps, constant pool values and exception handlers.} *)
 
-  val stack_map : stackmap -> string
+  (* val stack_map : stackmap_frame -> string *)
 
   val constant : constant -> string
 

--- a/src/javalib.mli
+++ b/src/javalib.mli
@@ -623,7 +623,7 @@ sig
 
   (** {1 Printing stackmaps, constant pool values and exception handlers.} *)
 
-  (* val stack_map : stackmap_frame -> string *)
+  val stack_map : stackmap_frame -> string
 
   val constant : constant -> string
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -15,20 +15,37 @@ all:javatests java/javac java/unparsed
 	diff java/javac/out java/unparsed/out
 
 	rm -f javatests/out/*
-	src/jar_parser `cat java/javac/out/Properties` -out javatests/out --silent
-	find . -type f -name '*.class' | xargs javap 1>/dev/null 2>.errors
+	if [ -s `cat java/javac/out/Properties` ]; then \
+	src/jar_parser `cat java/javac/out/Properties` -out javatests/out --silent; \
+	find ./javatests/out -type f -name '*.class' | xargs javap 1>/dev/null 2>.errors; \
+	fi
+
+	rm -f javatests/out/*
 	src/test_parser --silent javatests/huge/
-	find . -type f -name '*.class' | xargs javap 1>/dev/null 2>>.errors
+	find ./javatests/out -type f -name '*.class' | xargs javap 1>/dev/null 2>>.errors
+
+	if [ -s `cat java/javac/out/JmodPath` ]; then \
+	rm -rf ./javatests/jmods/*; \
+	bash java/java_jmods.sh; \
+	find ./javatests/jmods/classes -type f -name "*.class" > javatests/jmods/classes.txt; \
+	rm -f javatests/out/*; \
+	src/unparser javatests/jmods/classes.txt -out javatests/out; \
+	find ./javatests/out -type f -name '*.class' | xargs javap 1>/dev/null 2>>.errors; \
+	fi
+
 	if [ -s .errors ]; then cat .errors >> /dev/stderr; exit 1; fi
 
 
-javatests: javatests/huge
-	mkdir -p javatests/out
+javatests: javatests/huge javatests/jmods
+	mkdir -p javatests
 
 javatests/huge:
-	mkdir -p javatests
+	mkdir -p javatests/out
 	wget -r -nH --cut-dirs=4 -np --reject="*.html,*.tmp" -e robots=off \
 	https://scm.gforge.inria.fr/anonscm/svn/javalib/tests/javatests/
+
+javatests/jmods:
+	mkdir -p javatests/jmods
 
 java/javac:
 	mkdir -p java/javac/out

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -14,7 +14,7 @@ all:javatests java/javac java/unparsed
 	bash java/java_exec_dump.sh unparsed
 	diff java/javac/out java/unparsed/out
 
-	rm -f javatests/out/*
+	find ./javatests/out -name "*.class" -delete
 	if [ -s `cat java/javac/out/Properties` ]; then \
 	src/jar_parser `cat java/javac/out/Properties` -out javatests/out --silent; \
 	find ./javatests/out -type f -name '*.class' | xargs javap 1>/dev/null 2>.errors; \
@@ -25,9 +25,10 @@ all:javatests java/javac java/unparsed
 	find ./javatests/out -type f -name '*.class' | xargs javap 1>/dev/null 2>>.errors
 
 	if [ -s `cat java/javac/out/JmodPath` ]; then \
+	cat java/javac/out/JmodPath; \
 	rm -rf ./javatests/jmods/*; \
 	bash java/java_jmods.sh; \
-	find ./javatests/jmods/classes -type f -name "*.class" > javatests/jmods/classes.txt; \
+	find ./javatests/jmods -type f -name "*.class" > javatests/jmods/classes.txt; \
 	rm -f javatests/out/*; \
 	src/unparser javatests/jmods/classes.txt -out javatests/out; \
 	find ./javatests/out -type f -name '*.class' | xargs javap 1>/dev/null 2>>.errors; \

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -6,6 +6,8 @@ all:javatests java/javac java/unparsed
 	@rm -f java/unparsed/out/*
 	@rm -f java/sources.txt
 	@rm -f java/classes.txt
+	@find ./javatests/out -name "*.class" -delete
+	@rm -rf ./javatests/out/*
 	@find ./java/src/ -type f -name "*.java" > java/sources.txt
 	bash java/javac.sh
 	@find ./java/javac -type f -name "*.class" > java/classes.txt
@@ -15,12 +17,14 @@ all:javatests java/javac java/unparsed
 	diff java/javac/out java/unparsed/out
 
 	find ./javatests/out -name "*.class" -delete
+	rm -rf ./javatests/out/*
 	if [ -s java/javac/out/Properties ]; then \
 	src/jar_parser `cat java/javac/out/Properties` -out javatests/out --silent; \
 	find ./javatests/out -type f -name '*.class' | xargs javap 1>/dev/null 2>.errors; \
 	fi
 
-	rm -f javatests/out/*
+	find ./javatests/out -name "*.class" -delete
+	rm -rf ./javatests/out/*
 	src/test_parser --silent javatests/huge/
 	find ./javatests/out -type f -name '*.class' | xargs javap 1>/dev/null 2>>.errors
 
@@ -28,7 +32,7 @@ all:javatests java/javac java/unparsed
 	rm -rf ./javatests/jmods/*; \
 	bash java/java_jmods.sh; \
 	find ./javatests/jmods -type f -name "*.class" > javatests/jmods/classes.txt; \
-	rm -f javatests/out/*; \
+	find ./javatests/out -name "*.class" -delete; \
 	src/unparser javatests/jmods/classes.txt -out javatests/out; \
 	find ./javatests/out -type f -name '*.class' | xargs javap 1>/dev/null 2>>.errors; \
 	fi

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -15,7 +15,7 @@ all:javatests java/javac java/unparsed
 	diff java/javac/out java/unparsed/out
 
 	find ./javatests/out -name "*.class" -delete
-	if [ -s `cat java/javac/out/Properties` ]; then \
+	if [ -s java/javac/out/Properties ]; then \
 	src/jar_parser `cat java/javac/out/Properties` -out javatests/out --silent; \
 	find ./javatests/out -type f -name '*.class' | xargs javap 1>/dev/null 2>.errors; \
 	fi
@@ -24,8 +24,7 @@ all:javatests java/javac java/unparsed
 	src/test_parser --silent javatests/huge/
 	find ./javatests/out -type f -name '*.class' | xargs javap 1>/dev/null 2>>.errors
 
-	if [ -s `cat java/javac/out/JmodPath` ]; then \
-	cat java/javac/out/JmodPath; \
+	if [ -s java/javac/out/JmodPath ]; then \
 	rm -rf ./javatests/jmods/*; \
 	bash java/java_jmods.sh; \
 	find ./javatests/jmods -type f -name "*.class" > javatests/jmods/classes.txt; \

--- a/tests/java/java_exec_dump.sh
+++ b/tests/java/java_exec_dump.sh
@@ -4,5 +4,7 @@ cd "$path/$1"
 for i in `ls *.class 2>/dev/null`
 do
     name=$(echo "$i" | cut -f 1 -d '.')
-    java $name > out/$name
+    if ! [[ $name == *'$'* ]]; then
+	java $name > out/$name
+    fi
 done

--- a/tests/java/java_jmods.sh
+++ b/tests/java/java_jmods.sh
@@ -1,0 +1,8 @@
+path=`cat java/javac/out/JmodPath`
+
+if [ -n "$path" ]; then
+    cp $path/*.jmod ./javatests/jmods
+    for file in `ls ./javatests/jmods/*.jmod`; do
+	jmod extract $file --dir ./javatests/jmods
+    done
+fi

--- a/tests/java/java_load_classes.sh
+++ b/tests/java/java_load_classes.sh
@@ -1,0 +1,17 @@
+classes=`find ./javatests/out -maxdepth 1 -type f -name '*.class' -printf '%f\n'`
+
+for fullname in $classes; do
+    rootname=${fullname%.class}
+    pathname=${rootname//\./\/}
+    dir=$(dirname $pathname)
+    mkdir -p ./javatests/out/$dir
+    src=./javatests/out/$fullname
+    dst=./javatests/out/$dir/$(basename $pathname).class
+    if [ $(realpath $src) != $(realpath $dst) ]; then
+       cp $src $dst
+    fi
+done
+
+for name in $classes; do
+    java -classpath :./java/javac:./javatests/out Loader ${name%.class}
+done

--- a/tests/java/src/HelloWorld.java
+++ b/tests/java/src/HelloWorld.java
@@ -1,7 +1,10 @@
-class HelloWorld {
+public class HelloWorld {
 
     public static void main(String[] args) {
-	System.out.println("Hello, World.");
+	String message = "Hello, World.";
+	if (message.contains(",")) {
+	    System.out.println(message);
+	}
     }
 
 }

--- a/tests/java/src/JmodPath.java
+++ b/tests/java/src/JmodPath.java
@@ -1,0 +1,11 @@
+public class JmodPath {
+    public static void main(String[] args)
+    {
+        String value = System.getProperty("java.home");
+	String[] parts = value.split("/");
+	String last = parts[parts.length-1];
+	if (! last.equals("jre")) {
+	    System.out.println(value.concat("/jmods"));
+	}
+    }
+}

--- a/tests/java/src/LambdaInvokeInterface.java
+++ b/tests/java/src/LambdaInvokeInterface.java
@@ -1,0 +1,35 @@
+public class LambdaInvokeInterface {
+
+    interface IT
+    {
+	public int get_v();
+    }
+
+    static class T implements IT
+    {
+	private int v;
+
+	public T(int v)
+	{
+	    this.v = v;
+	}
+
+	public int get_v()
+	{
+	    return this.v;
+	}
+    }
+
+    interface I
+    {
+	public int op(T t);
+    }
+
+    public static void main(String[] args)
+    {
+	I f = IT::get_v;
+	T t = new T(42);
+	int v = f.op(t);
+	System.out.println(v);
+    }
+}

--- a/tests/java/src/LambdaInvokeSpecial.java
+++ b/tests/java/src/LambdaInvokeSpecial.java
@@ -1,0 +1,40 @@
+public class LambdaInvokeSpecial {
+
+    class T
+    {
+	private int v;
+
+	public T(int v)
+	{
+	    this.v = v;
+	}
+
+	public int get_v()
+	{
+	    return this.v;
+	}
+    }
+
+    public T get_T()
+    {
+	return new T(42);
+    }
+    
+    interface I
+    {
+	public T op();
+    }
+
+    public int test()
+    {
+	I f = () -> this.get_T();
+	int v = f.op().get_v();
+	return v;
+    }
+    
+    public static void main(String[] args)
+    {
+	int v = (new LambdaInvokeSpecial()).test();
+	System.out.println(v);
+    }
+}

--- a/tests/java/src/LambdaInvokeStatic.java
+++ b/tests/java/src/LambdaInvokeStatic.java
@@ -1,0 +1,30 @@
+public class LambdaInvokeStatic {
+
+    static class T
+    {
+	private int v;
+
+	public T(int v)
+	{
+	    this.v = v;
+	}
+
+	public int get_v()
+	{
+	    return this.v;
+	}
+    }
+
+    interface I
+    {
+	public int op(T t);
+    }
+
+    public static void main(String[] args)
+    {
+	I f = (T t) -> t.get_v();
+	T t = new T(42);
+	int v = f.op(t);
+	System.out.println(v);
+    }
+}

--- a/tests/java/src/LambdaInvokeVirtual.java
+++ b/tests/java/src/LambdaInvokeVirtual.java
@@ -1,0 +1,30 @@
+public class LambdaInvokeVirtual {
+
+    static class T
+    {
+	private int v;
+
+	public T(int v)
+	{
+	    this.v = v;
+	}
+
+	public int get_v()
+	{
+	    return this.v;
+	}
+    }
+
+    interface I
+    {
+	public int op(T t);
+    }
+
+    public static void main(String[] args)
+    {
+	I f = T::get_v;
+	T t = new T(42);
+	int v = f.op(t);
+	System.out.println(v);
+    }
+}

--- a/tests/java/src/Properties.java
+++ b/tests/java/src/Properties.java
@@ -2,6 +2,8 @@ public class Properties {
     public static void main(String[] args)
         throws Exception {
         String value = System.getProperty("sun.boot.class.path");
-        System.out.println(value);
+	if (value != null) {
+	    System.out.println(value);
+	}
     }
 }


### PR DESCRIPTION
* Java 9 changes
  - ConstantModule
  - ConstantPackage
  - Tested successfully with openjdk11 (all modules)
* Stackmap format
  - reverting to low level format for correctness
  - fixes class loading bug after unparsing
* Bugfix in JParseSignature
  - correcting stupid bug with classes starting by 'L' which where not in a package
  - the correction is just one line deletion in jParseSignature.ml
* JFile
  - sep is now a char instead of a string of length 1
* Permissive
  - if JBasics.get_permissive() is true, we allow a class that is neither a module nor Object to have no superclass
* More java tests for _invokedynamic_ instruction