### PR TITLE
Features + bugfix

### DIFF
--- a/src/jDumpBasics.ml
+++ b/src/jDumpBasics.ml
@@ -168,7 +168,7 @@ let rec dump_constant ch = function
         (method_signature "" ms)
   | ConstMethodHandle mh ->
      let (hk, c) = JBasicsLow.method_handle_to_const mh in
-     JLib.IO.printf ch "method-handle : %s" (method_handle_kind hk);
+     JLib.IO.printf ch "method-handle : %s, " (method_handle_kind hk);
      (dump_constant ch c)
   | ConstInvokeDynamic (bmi, ms) ->
       JLib.IO.printf ch "invoke-dynamic : %d %s"
@@ -188,16 +188,18 @@ let dump_bootstrap_argument ch = function
   | `MethodType ms -> dump_constant ch (ConstMethodType ms)
 
 let dump_bootstrap_method ch { bm_ref; bm_args; } =
-  JLib.IO.nwrite_string ch "    method_ref = ";
+  JLib.IO.nwrite_string ch "\t method_ref {\n\t   ";
   dump_constant ch (ConstMethodHandle bm_ref);
+  JLib.IO.nwrite_string ch "\n\t }\n\t";
   if bm_args <> []
   then
     begin
-      JLib.IO.nwrite_string ch (" , bootstrap_arguments = ");
+      JLib.IO.nwrite_string ch (" bootstrap_arguments {\n\t");
       List.iter (fun arg ->
+          JLib.IO.nwrite_string ch "   ";
           dump_bootstrap_argument ch arg;
-          JLib.IO.nwrite_string ch "\n") bm_args
-    end
+          JLib.IO.nwrite_string ch "\n\t") bm_args
+    end; JLib.IO.nwrite_string ch " }"
 
 let dump_constantpool ch =
   Array.iteri

--- a/src/jPrint.ml
+++ b/src/jPrint.ml
@@ -348,9 +348,12 @@ let jopcode_jvm =
       | `Interface cs ->
 	 "invokeinterface " ^
            (method_signature ~jvm:true ~callee:(TClass cs) ms)
-      | `Dynamic _ ->
+      | `Dynamic bm ->
+         let ch = JLib.IO.output_string () in
+         let () = JDumpBasics.dump_bootstrap_method ch bm in
          "invokedynamic " ^
-           (method_signature ~jvm:true ms)
+           (method_signature ~jvm:true ms) ^ "\n"
+           ^ (JLib.IO.close_out ch)
      )
   | OpNew cs -> "new " ^ (class_name cs)
   | OpNewArray t ->


### PR DESCRIPTION
* printing correctly `invokedynamic` instructions in `JPrint`
* bugfix in `JParseSignature` : don't consider anymore '-', '+' and '*' as special tokens (they can appear in package or class names)

 This closes #11, closes #12, and closes #15.