### PR TITLE
Use Stdlib instead of Pervasives

### DIFF
--- a/javalib.opam
+++ b/javalib.opam
@@ -13,7 +13,7 @@ build: [
 ]
 install: [make "install"]
 depends: [
-  "ocaml" {>= "4.04"}
+  "ocaml" {>= "4.08"}
   "conf-which" {build}
   "ocamlfind" {build}
   "camlzip" {>= "1.05"}

--- a/javalib.opam
+++ b/javalib.opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 name: "javalib"
-version: "3.2"
+version: "3.2.2"
 maintainer: "Nicolas Barré <nicolas.barre@irisa.fr>"
 authors: "Javalib Development team"
 homepage: "https://javalib-team.github.io/javalib/"

--- a/src/META.source
+++ b/src/META.source
@@ -1,4 +1,4 @@
-version = "3.2"
+version = "3.2.2"
 description = "library to parse Java .class files"
 archive(native) = "javalib.cmxa"
 archive(byte) = "javalib.cma"

--- a/src/jFile.ml
+++ b/src/jFile.ml
@@ -120,7 +120,7 @@ let lookup c : cp_unit -> JClassLow.jclass =
 	    | `dir d ->
 		if is_file (Filename.concat d c)
 		then
-		  let ch = Pervasives.open_in_bin (Filename.concat d c) in
+		  let ch = Stdlib.open_in_bin (Filename.concat d c) in
 		    JLib.IO.input_channel ch
 		else raise Not_found
 	    | `jar jar ->
@@ -156,7 +156,7 @@ let write_class_low output_dir classe =
     (mkdir
        (Filename.concat output_dir (Filename.dirname c))
        0o755);
-    let f = Pervasives.open_out_bin (Filename.concat output_dir c) in
+    let f = Stdlib.open_out_bin (Filename.concat output_dir c) in
     let output = JLib.IO.output_channel f in
       JUnparse.unparse_class_low_level output classe;
       JLib.IO.close_out output
@@ -171,7 +171,7 @@ let dir_sep =
     | _ -> assert false (* Inspirated from filename.ml in the stdlib *)
 
 let extract_class_name_from_file file =
-  let input = JLib.IO.input_channel (Pervasives.open_in_bin file) in
+  let input = JLib.IO.input_channel (Stdlib.open_in_bin file) in
   let c = JParse.parse_class_low_level input in
     JLib.IO.close_in input;
     let cname = c.j_name in
@@ -291,7 +291,7 @@ let fold_string class_path f file =
       try
 	apply_to_dir_or_class
 	  (function c ->
-	     let ch = Pervasives.open_in_bin c in
+	     let ch = Stdlib.open_in_bin c in
 	     let input = JLib.IO.input_channel ch in
 	     let classe = JParse.parse_class_low_level input in
 	       JLib.IO.close_in input;

--- a/src/ptrees/ptset.ml
+++ b/src/ptrees/ptset.ml
@@ -335,7 +335,7 @@ let elements s =
   in
   (* unfortunately there is no easy way to get the elements in ascending
      order with little-endian Patricia trees *)
-  List.sort Pervasives.compare (elements_aux [] s)
+  List.sort Stdlib.compare (elements_aux [] s)
 
 let split x s =
   let coll k (l, b, r) =
@@ -599,7 +599,7 @@ module Big = struct
       | Branch (_,_,l,r) -> elements_aux (elements_aux acc r) l
     in
     (* we still have to sort because of possible negative elements *)
-    List.sort Pervasives.compare (elements_aux [] s)
+    List.sort Stdlib.compare (elements_aux [] s)
 
   let split x s =
     let coll k (l, b, r) =


### PR DESCRIPTION
Pervasives was deprecated in favor of directly using Stdlib in 4.08 and then removed in the upcoming 5.0. This change makes javalib buildable with the multi-core ocaml 5.0~alpha.