### PR TITLE
Fix a regression in List.split_nth impl

### DIFF
--- a/src/jLib.ml
+++ b/src/jLib.ml
@@ -48,7 +48,7 @@ module List = struct
       | 0, _ -> (List.rev l1, l2)
       | _, [] -> raise (Invalid_index n)
       | _, x :: l2 -> aux (i-1) (x::l1) l2
-    in aux 0 [] l
+    in aux n [] l
     
        
 end                  


### PR DESCRIPTION
**Summary**:
The regression was introduced in https://github.com/javalib-team/javalib/commit/84103ca68b6f97c8b26e75064c71430ea043b9c9

In particular it causes infer to either spin indefinitely or simply produce wrong results.

This PR fixes a bug, but NOTE that the new implementation has a different semantics from that of `take_drop` in Collections. Anyway, this patch makes everything work nicely in infer.

**Test Plan**:
Tested manually. Would be nice to add some unit tests but perhaps for another time.